### PR TITLE
Adding spring actuator endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <name>Manuel Bernal-Llinares</name>
             <email>mbdebian@gmail.com</email>
             <organization>EMBL-European Bioinformatics Institute</organization>
-            <organizationUrl>http://ebi.ac.uk/</organizationUrl>
+            <organizationUrl>https://ebi.ac.uk/</organizationUrl>
             <timezone>Europe/London</timezone>
             <roles>
                 <role>architect</role>
@@ -64,6 +64,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -123,13 +127,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>RELEASE</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/HealthApiController.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/HealthApiController.java
@@ -2,6 +2,7 @@ package org.identifiers.cloud.hq.ws.registry.api.controllers;
 
 import org.identifiers.cloud.hq.ws.registry.api.models.HealthApiModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 //@RequestMapping("healthApi")
+@Deprecated
+@ConditionalOnProperty(value = "management.endpoint.health.enabled",
+    matchIfMissing = true, havingValue = "false")
 public class HealthApiController {
     @Autowired
     private HealthApiModel model;

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/HealthApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/HealthApiModel.java
@@ -1,5 +1,7 @@
 package org.identifiers.cloud.hq.ws.registry.api.models;
 
+import org.identifiers.cloud.hq.ws.registry.api.controllers.HealthApiController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -13,6 +15,8 @@ import java.util.UUID;
  * ---
  */
 @Component
+@Deprecated
+@ConditionalOnBean(HealthApiController.class)
 public class HealthApiModel {
     private static String runningSessionId = UUID.randomUUID().toString();
 

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/configuration/AuthSecurityConfiguration.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/configuration/AuthSecurityConfiguration.java
@@ -50,6 +50,9 @@ public class AuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${spring.security.oauth2.client.registration.keycloak.grantType}")
     private String grantType;
 
+    @Value("${org.identifiers.cloud.hq.ws.registry.requiredrole}")
+    private String actuatorRequiredRole;
+
     @PostConstruct
     private void postConstruct() {
         log.info("[CONFIG] (AAA) ENABLED");
@@ -277,6 +280,10 @@ public class AuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.POST, "/fairapi/coverage/**").permitAll()
                     .antMatchers(HttpMethod.POST, "/fairapi/interoperability/**").permitAll()
                     .antMatchers(HttpMethod.GET, "/fairapi/health/**").permitAll()
+                // Actuators
+                    .antMatchers(HttpMethod.GET, "/actuator/health/**").permitAll()
+                    .antMatchers("/actuator").access(String.format("isAuthenticated() and principal.claims['realm_access']['roles'].contains('%s')", actuatorRequiredRole))
+                    .antMatchers("/actuator/loggers/**").access(String.format("isAuthenticated() and principal.claims['realm_access']['roles'].contains('%s')", actuatorRequiredRole))
                 .anyRequest().denyAll()
                 .and()
                 .csrf()
@@ -286,6 +293,7 @@ public class AuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
                     .ignoringAntMatchers("/resourceManagementApi/validate*")
                     .ignoringAntMatchers("/rorIdApi/**")
                     .ignoringAntMatchers("/fairapi/**")
+                    .ignoringAntMatchers("/actuator/**")
                 .and()
                 .cors()
                 .and()

--- a/src/main/resources/application-authenabled.yml
+++ b/src/main/resources/application-authenabled.yml
@@ -1,4 +1,9 @@
 # This file contains properties to be used when AAA is enabled, this configuration contains both resource server and client information
+management:
+  endpoint:
+    health:
+      show-details: when_authorized
+
 spring:
   security:
     oauth2:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,3 +117,38 @@ org.identifiers.matomo.enabled=${MATOMO_ENABLED:false}
 org.identifiers.matomo.authToken=${MATOMO_AUTH_TOKEN:replaceMe}
 #The base URL bellow should be without /matomo.php at the end
 org.identifiers.matomo.baseUrl=${MATOMO_BASE_URL:https://matomo.identifiers.org}
+
+### Spring actuators
+org.identifiers.cloud.hq.ws.registry.requiredrole=${HQ_WS_REGISTRY_CONFIG_BACKEND_REQUIRED_ROLE:chad}
+management.endpoints.jmx.exposure.exclude=*
+management.endpoint.loggers.enabled=true
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=always
+# DB is the only thing this application needs to keep running
+management.health.defaults.enabled=false
+management.health.db.enabled=true
+
+management.endpoints.web.exposure.include=loggers,health
+
+# Deactivations for peace of mind - likely unnecessary
+management.endpoint.auditevents.enabled=false
+management.endpoint.beans.enabled=false
+management.endpoint.caches.enabled=false
+management.endpoint.conditions.enabled=false
+management.endpoint.configprops.enabled=false
+management.endpoint.env.enabled=false
+management.endpoint.flyway.enabled=false
+management.endpoint.httptrace.enabled=false
+management.endpoint.info.enabled=false
+management.endpoint.integrationgraph.enabled=false
+management.endpoint.liquibase.enabled=false
+management.endpoint.metrics.enabled=false
+management.endpoint.mappings.enabled=false
+management.endpoint.scheduledtasks.enabled=false
+management.endpoint.sessions.enabled=false
+management.endpoint.shutdown.enabled=false
+management.endpoint.threaddump.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.jolokia.enabled=false
+management.endpoint.logfile.enabled=false
+management.endpoint.prometheus.enabled=false


### PR DESCRIPTION
Replaced legacy health checkers for spring endpoint health check with custom indicators for the thread; Loggers endpoint enabled for production debug when needed; Added spring security for only authenticated users to access loggers actuator
