### PR TITLE
Protected resources

### DIFF
--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/PrefixRegistrationRequestValidationApiController.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/PrefixRegistrationRequestValidationApiController.java
@@ -142,4 +142,16 @@ public class PrefixRegistrationRequestValidationApiController {
         ServiceResponseRegisterPrefixValidateRequest response = model.validateRequesterEmail(request);
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
+
+    @PostMapping(value = "/validateAuthHelpDescription")
+    public ResponseEntity<?> validateAuthHelpDescription(@RequestBody ServiceRequestRegisterPrefixValidate request) {
+        ServiceResponseRegisterPrefixValidateRequest response = model.validateAuthHelpDescription(request);
+        return new ResponseEntity<>(response, response.getHttpStatus());
+    }
+
+    @PostMapping(value = "/validateAuthHelpUrl")
+    public ResponseEntity<?> validateAuthHelpUrl(@RequestBody ServiceRequestRegisterPrefixValidate request) {
+        ServiceResponseRegisterPrefixValidateRequest response = model.validateAuthHelpUrl(request);
+        return new ResponseEntity<>(response, response.getHttpStatus());
+    }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/ResourceManagementApiController.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/ResourceManagementApiController.java
@@ -161,6 +161,19 @@ public class ResourceManagementApiController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
+    @PostMapping(value = "/validateAuthHelpDescription")
+    public ResponseEntity<?> validateAuthHelpDescription(@RequestBody ServiceRequestRegisterResourceValidate request) {
+        ServiceResponseRegisterResourceValidate response = model.validateAuthHelpDescription(request);
+        return new ResponseEntity<>(response, response.getHttpStatus());
+    }
+
+    @PostMapping(value = "/validateAuthHelpUrl")
+    public ResponseEntity<?> validateAuthHelpUrl(@RequestBody ServiceRequestRegisterResourceValidate request) {
+        ServiceResponseRegisterResourceValidate response = model.validateAuthHelpUrl(request);
+        return new ResponseEntity<>(response, response.getHttpStatus());
+    }
+
+
     // --- Resource Lifecycle Management
     @GetMapping(value = "/deactivateResource/{resourceId}")
     public ResponseEntity<?> deactivateResource(@PathVariable long resourceId) {

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/RestResponseEntityExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -23,6 +24,15 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         // Date for easier finding related entries in log files
         Calendar cal = Calendar.getInstance();
         return sdf.format(cal.getTime());
+    }
+
+    @ExceptionHandler(value = { ResourceNotFoundException.class })
+    protected ResponseEntity<Object> handleResourceNotFound (ResourceNotFoundException ex, WebRequest request) {
+        ServiceResponse responseBody = new ServiceResponse()
+                .setApiVersion(ApiCentral.apiVersion)
+                .setErrorMessage(ex.getMessage());
+        return handleExceptionInternal(ex, responseBody, new HttpHeaders(),
+                HttpStatus.NOT_FOUND, request);
     }
 
     @ExceptionHandler(value = { RuntimeException.class })

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/data/helpers/ApiAndDataModelsHelper.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/data/helpers/ApiAndDataModelsHelper.java
@@ -50,7 +50,11 @@ public class ApiAndDataModelsHelper {
                 .setAdditionalInformation(additionalInformation)
                 .setNamespaceEmbeddedInLui(sourceModel.isNamespaceEmbeddedInLui())
                 .setRequesterName(sourceModel.getRequester().getName())
-                .setRequesterEmail(sourceModel.getRequester().getEmail());
+                .setRequesterEmail(sourceModel.getRequester().getEmail())
+                .setProtectedUrls(sourceModel.isProtectedUrls())
+                .setRenderProtectedLanding(sourceModel.isRenderProtectedLanding())
+                .setAuthHelpDescription(sourceModel.getAuthHelpDescription())
+                .setAuthHelpUrl(sourceModel.getAuthHelpUrl());
     }
 
     // NOTE - I don't totally like to have two models with the same name, as it makes the coding more prone to
@@ -87,7 +91,11 @@ public class ApiAndDataModelsHelper {
                 .setInstitution(getInstitutionFrom(resource.getInstitution()))
                 .setLocation(getLocationFrom(resource.getLocation()))
                 .setDeprecated(resource.isDeprecated())
-                .setDeprecationDate(resource.getDeprecationDate());
+                .setDeprecationDate(resource.getDeprecationDate())
+                .setProtectedUrls(resource.isProtectedUrls())
+                .setRenderProtectedLanding(resource.isRenderProtectedLanding())
+                .setAuthHelpDescription(resource.getAuthHelpDescription())
+                .setAuthHelpUrl(resource.getAuthHelpUrl());
     }
 
     public static Namespace getNamespaceFrom(org.identifiers.cloud.hq.ws.registry.data.models.Namespace namespace) {
@@ -124,7 +132,11 @@ public class ApiAndDataModelsHelper {
                 .setProviderName(payload.getProviderName())
                 .setProviderUrlPattern(payload.getProviderUrlPattern())
                 .setRequesterEmail(payload.getRequester().getEmail())
-                .setRequesterName(payload.getRequester().getName());
+                .setRequesterName(payload.getRequester().getName())
+                .setProtectedUrls(payload.isProtectedUrls())
+                .setRenderProtectedLanding(payload.isRenderProtectedLanding())
+                .setAuthHelpDescription(payload.getAuthHelpDescription())
+                .setAuthHelpUrl(payload.getAuthHelpUrl());
     }
 
     // Get a Prefix Registration Request Payload from a Resource Registration Request Payload
@@ -144,6 +156,10 @@ public class ApiAndDataModelsHelper {
                 .setProviderLocation(payload.getProviderLocation())
                 .setProviderName(payload.getProviderName())
                 .setProviderUrlPattern(payload.getProviderUrlPattern())
-                .setRequestedPrefix(payload.getNamespacePrefix());
+                .setRequestedPrefix(payload.getNamespacePrefix())
+                .setProtectedUrls(payload.isProtectedUrls())
+                .setRenderProtectedLanding(payload.isRenderProtectedLanding())
+                .setAuthHelpDescription(payload.getAuthHelpDescription())
+                .setAuthHelpUrl(payload.getAuthHelpUrl());
     }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/data/models/Resource.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/data/models/Resource.java
@@ -5,7 +5,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-
 import java.io.Serializable;
 import java.util.Date;
 
@@ -46,5 +45,10 @@ public class Resource implements Serializable {
     private boolean deprecated;
     // Information on when this resource was deprecated
     private Date deprecationDate;
+
+    private boolean protectedUrls;
+    private boolean renderProtectedLanding;
+    private String authHelpUrl;
+    private String authHelpDescription;
 
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/PrefixRegistrationRequestApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/PrefixRegistrationRequestApiModel.java
@@ -140,7 +140,6 @@ public class PrefixRegistrationRequestApiModel {
 
     public ServiceResponseRegisterPrefixSessionEvent amendPrefixRegistrationRequest(long sessionId, ServiceRequestRegisterPrefixSessionEvent request) {
         ServiceResponseRegisterPrefixSessionEvent response = createRegisterPrefixSessionEventDefaultResponse();
-        // TODO Actor unknnown right now, until we get Spring Security
         String actor = authHelper.getCurrentUsername();
         // Locate the prefix registration request session
         PrefixRegistrationSession prefixRegistrationSession = getPrefixRegistrationSession("AMEND", sessionId, request, response);
@@ -158,7 +157,6 @@ public class PrefixRegistrationRequestApiModel {
 
     public ServiceResponseRegisterPrefixSessionEvent commentPrefixRegistrationRequest(long sessionId, ServiceRequestRegisterPrefixSessionEvent request) {
         ServiceResponseRegisterPrefixSessionEvent response = createRegisterPrefixSessionEventDefaultResponse();
-        // TODO Actor unknnown right now, until we get Spring Security
         String actor = authHelper.getCurrentUsername();
         // Locate the prefix registration request session
         PrefixRegistrationSession prefixRegistrationSession = getPrefixRegistrationSession("COMMENT", sessionId, request, response);
@@ -170,10 +168,8 @@ public class PrefixRegistrationRequestApiModel {
         return response;
     }
 
-    // TODO - Reject prefix registration request
     public ServiceResponseRegisterPrefixSessionEvent rejectPrefixRegistrationRequest(long sessionId, ServiceRequestRegisterPrefixSessionEvent request) {
         ServiceResponseRegisterPrefixSessionEvent response = createRegisterPrefixSessionEventDefaultResponse();
-        // TODO Actor unknnown right now, until we get Spring Security
         String actor = authHelper.getCurrentUsername();
         // Locate the prefix registration request session
         PrefixRegistrationSession prefixRegistrationSession = getPrefixRegistrationSession("REJECT", sessionId, request, response);
@@ -184,10 +180,8 @@ public class PrefixRegistrationRequestApiModel {
         return response;
     }
 
-    // TODO - Accept prefix registration request
     public ServiceResponseRegisterPrefixSessionEvent acceptPrefixRegistrationRequest(long sessionId, ServiceRequestRegisterPrefixSessionEvent request) {
         ServiceResponseRegisterPrefixSessionEvent response = createRegisterPrefixSessionEventDefaultResponse();
-        // TODO Actor unknnown right now, until we get Spring Security
         String actor = authHelper.getCurrentUsername();
         // Locate the prefix registration request session
         PrefixRegistrationSession prefixRegistrationSession = getPrefixRegistrationSession("ACCEPT", sessionId, request, response);

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/PrefixRegistrationRequestValidationApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/PrefixRegistrationRequestValidationApiModel.java
@@ -102,6 +102,14 @@ public class PrefixRegistrationRequestValidationApiModel {
     @Qualifier("PrefixRegistrationRequestValidatorRequesterEmail")
     private PrefixRegistrationRequestValidator requesterEmailValidator;
 
+    @Autowired
+    @Qualifier("PrefixRegistrationRequestValidatorAuthHelpDescription")
+    private PrefixRegistrationRequestValidator authHelpDescriptionValidator;
+
+    @Autowired
+    @Qualifier("PrefixRegistrationRequestValidatorAuthHelpUrl")
+    private PrefixRegistrationRequestValidator authHelpUrlValidator;
+
     // -- Helpers --
 
     /**
@@ -215,5 +223,13 @@ public class PrefixRegistrationRequestValidationApiModel {
 
     public ServiceResponseRegisterPrefixValidateRequest validateRequesterEmail(ServiceRequestRegisterPrefixValidate request) {
         return doValidation(request, requesterEmailValidator);
+    }
+
+    public ServiceResponseRegisterPrefixValidateRequest validateAuthHelpDescription(ServiceRequestRegisterPrefixValidate request) {
+        return doValidation(request, authHelpDescriptionValidator);
+    }
+
+    public ServiceResponseRegisterPrefixValidateRequest validateAuthHelpUrl(ServiceRequestRegisterPrefixValidate request) {
+        return doValidation(request, authHelpUrlValidator);
     }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResourceManagementApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResourceManagementApiModel.java
@@ -106,6 +106,14 @@ public class ResourceManagementApiModel {
     @Qualifier("ResourceRegistrationRequestValidatorRequesterEmail")
     private ResourceRegistrationRequestValidator requesterEmailValidator;
 
+    @Autowired
+    @Qualifier("ResourceRegistrationRequestValidatorAuthHelpDescription")
+    private ResourceRegistrationRequestValidator authHelpDescriptionValidator;
+
+    @Autowired
+    @Qualifier("ResourceRegistrationRequestValidatorAuthHelpUrl")
+    private ResourceRegistrationRequestValidator authHelpUrlValidator;
+
     // Resource Registration Request validation strategy
     @Autowired
     private ResourceRegistrationRequestValidatorStrategy validatorStrategy;
@@ -378,6 +386,14 @@ public class ResourceManagementApiModel {
 
     public ServiceResponseRegisterResourceValidate validateNamespacePrefix(ServiceRequestRegisterResourceValidate request) {
         return doValidation(request, namespacePrefixValidator);
+    }
+
+    public ServiceResponseRegisterResourceValidate validateAuthHelpDescription(ServiceRequestRegisterResourceValidate request) {
+        return doValidation(request, authHelpDescriptionValidator);
+    }
+
+    public ServiceResponseRegisterResourceValidate validateAuthHelpUrl(ServiceRequestRegisterResourceValidate request) {
+        return doValidation(request, authHelpUrlValidator);
     }
 
     // TODO --- Resource Lifecycle Management API

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/requests/ServiceRequestRegisterPrefixPayload.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/requests/ServiceRequestRegisterPrefixPayload.java
@@ -80,4 +80,12 @@ public class ServiceRequestRegisterPrefixPayload implements Serializable {
 
     // Flag whether this namespace has LUIs with namespace embedded, which is a special case, as they're allowed to omit their namespace when hitting the resolver.
     private boolean namespaceEmbeddedInLui = false;
+
+    ////// Protected resource string
+    private boolean protectedUrls;
+    private boolean renderProtectedLanding;
+    private String authHelpUrl;
+    private String authHelpDescription;
+
+
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/requests/ServiceRequestRegisterResourcePayload.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/requests/ServiceRequestRegisterResourcePayload.java
@@ -67,4 +67,10 @@ public class ServiceRequestRegisterResourcePayload implements Serializable {
 
     private String additionalInformation;
     private Requester requester;
+
+    ////// Protected resource string
+    private boolean protectedUrls;
+    private boolean renderProtectedLanding;
+    private String authHelpUrl;
+    private String authHelpDescription;
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/Namespace.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/Namespace.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Project: registry
@@ -102,4 +103,7 @@ public class Namespace {
 
     @ManyToOne
     private Person contactPerson;
+
+    @OneToMany(mappedBy = "namespace")
+    private List<Resource> resources;
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/PrefixRegistrationRequest.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/PrefixRegistrationRequest.java
@@ -3,6 +3,8 @@ package org.identifiers.cloud.hq.ws.registry.data.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.experimental.Accessors;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -127,4 +129,16 @@ public class PrefixRegistrationRequest {
     @CreatedDate
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Date created;
+
+
+    private boolean protectedUrls;
+
+    private boolean renderProtectedLanding;
+
+    @URL(regexp = "^(http|https).*$")
+    private String authHelpUrl;
+
+    @Column(length = 2000)
+    @Length(min = 50)
+    private String authHelpDescription;
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/Resource.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/Resource.java
@@ -1,11 +1,10 @@
 package org.identifiers.cloud.hq.ws.registry.data.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.Accessors;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -96,4 +95,18 @@ public class Resource {
 
     @ManyToOne
     private Person contactPerson;
+
+
+
+    ////// Protected resource string
+    private boolean protectedUrls;
+
+    private boolean renderProtectedLanding;
+
+    @URL(regexp = "^(http|https).*$")
+    private String authHelpUrl;
+
+    @Column(length = 2000)
+    @Length(min = 50)
+    private String authHelpDescription;
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/ResourceRegistrationRequest.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/data/models/ResourceRegistrationRequest.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -104,4 +106,16 @@ public class ResourceRegistrationRequest {
     @CreatedDate
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Date created;
+
+
+    private boolean protectedUrls;
+
+    private boolean renderProtectedLanding;
+
+    @URL(regexp = "^(http|https).*$")
+    private String authHelpUrl;
+
+    @Column(length = 2000)
+    @Length(min = 50)
+    private String authHelpDescription;
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/DataModelConversionHelper.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/DataModelConversionHelper.java
@@ -51,7 +51,11 @@ public class DataModelConversionHelper {
                 .setOfficial(true)
                 .setProviderCode(prefixRegistrationRequest.getProviderCode())
                 .setSampleId(prefixRegistrationRequest.getSampleId())
-                .setResourceHomeUrl(prefixRegistrationRequest.getProviderHomeUrl());
+                .setResourceHomeUrl(prefixRegistrationRequest.getProviderHomeUrl())
+                .setAuthHelpDescription(prefixRegistrationRequest.getAuthHelpDescription())
+                .setAuthHelpUrl(prefixRegistrationRequest.getAuthHelpUrl())
+                .setProtectedUrls(prefixRegistrationRequest.isProtectedUrls())
+                .setRenderProtectedLanding(prefixRegistrationRequest.isRenderProtectedLanding());
         return resource;
     }
 
@@ -81,7 +85,11 @@ public class DataModelConversionHelper {
                 .setDescription(resourceRegistrationRequest.getProviderDescription())
                 .setProviderCode(resourceRegistrationRequest.getProviderCode())
                 .setSampleId(resourceRegistrationRequest.getSampleId())
-                .setResourceHomeUrl(resourceRegistrationRequest.getProviderHomeUrl());
+                .setResourceHomeUrl(resourceRegistrationRequest.getProviderHomeUrl())
+                .setAuthHelpDescription(resourceRegistrationRequest.getAuthHelpDescription())
+                .setAuthHelpUrl(resourceRegistrationRequest.getAuthHelpUrl())
+                .setProtectedUrls(resourceRegistrationRequest.isProtectedUrls())
+                .setRenderProtectedLanding(resourceRegistrationRequest.isRenderProtectedLanding());
         return resource;
     }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorAuthHelpDescription.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorAuthHelpDescription.java
@@ -1,0 +1,37 @@
+package org.identifiers.cloud.hq.ws.registry.models.validators;
+
+import org.identifiers.cloud.hq.ws.registry.api.requests.ServiceRequestRegisterPrefixPayload;
+import org.identifiers.cloud.hq.ws.registry.models.helpers.ResourceAccessHelper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Project: registry
+ * Package: org.identifiers.cloud.hq.ws.registry.models.validators
+ * Timestamp: 2019-03-14 15:49
+ *
+ * @author Manuel Bernal Llinares <mbdebian@gmail.com>
+ * ---
+ */
+// TODO I don't think it needs to be of "prototype" scope
+@Component
+@Scope("prototype")
+@Qualifier("PrefixRegistrationRequestValidatorAuthHelpDescription")
+public class PrefixRegistrationRequestValidatorAuthHelpDescription implements PrefixRegistrationRequestValidator {
+    public static final int DESCRIPTION_CONTENT_MIN_CHARS = 50;
+
+    @Override
+    public boolean validate(ServiceRequestRegisterPrefixPayload request) throws PrefixRegistrationRequestValidatorException {
+        if (request.isProtectedUrls()) {
+            if (request.getAuthHelpDescription() == null ||
+                    request.getAuthHelpDescription().length() < DESCRIPTION_CONTENT_MIN_CHARS) {
+                throw new PrefixRegistrationRequestValidatorException(
+                        String.format("Authentication description must be longer than %d characters",
+                                DESCRIPTION_CONTENT_MIN_CHARS));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorAuthHelpUrl.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorAuthHelpUrl.java
@@ -1,0 +1,39 @@
+package org.identifiers.cloud.hq.ws.registry.models.validators;
+
+import org.identifiers.cloud.hq.ws.registry.api.requests.ServiceRequestRegisterPrefixPayload;
+import org.identifiers.cloud.hq.ws.registry.models.helpers.ResourceAccessHelper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Project: registry
+ * Package: org.identifiers.cloud.hq.ws.registry.models.validators
+ * Timestamp: 2019-03-14 15:49
+ *
+ * @author Manuel Bernal Llinares <mbdebian@gmail.com>
+ * ---
+ */
+// TODO I don't think it needs to be of "prototype" scope
+@Component
+@Scope("prototype")
+@Qualifier("PrefixRegistrationRequestValidatorAuthHelpUrl")
+public class PrefixRegistrationRequestValidatorAuthHelpUrl implements PrefixRegistrationRequestValidator {
+    @Override
+    public boolean validate(ServiceRequestRegisterPrefixPayload request) throws PrefixRegistrationRequestValidatorException {
+        if (request.isProtectedUrls()) {
+            if (request.getAuthHelpUrl() == null || request.getAuthHelpUrl().trim().length() == 0) {
+                throw new PrefixRegistrationRequestValidatorException("MISSING required authentication info URL");
+            }
+            if (!request.getAuthHelpUrl().toLowerCase().startsWith("http")) {
+                throw new PrefixRegistrationRequestValidatorException("INVALID authentication info URL, it must be a HTTP(S) URL");
+            }
+            WebPageChecker webPageChecker = WebPageCheckerFactory.getWebPageChecker();
+            if (!webPageChecker.checkForValidUrl(request.getAuthHelpUrl())) {
+                throw new PrefixRegistrationRequestValidatorException(String.format("Invalid URL '%s'", request.getAuthHelpUrl()));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorStrategyFullValidation.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/PrefixRegistrationRequestValidatorStrategyFullValidation.java
@@ -92,6 +92,14 @@ public class PrefixRegistrationRequestValidatorStrategyFullValidation implements
     @Qualifier("prefixRegistrationRequestValidatorRequester")
     private PrefixRegistrationRequestValidator requesterValidator;
 
+    @Autowired
+    @Qualifier("PrefixRegistrationRequestValidatorAuthHelpDescription")
+    private PrefixRegistrationRequestValidator authHelpDescriptionValidator;
+
+    @Autowired
+    @Qualifier("PrefixRegistrationRequestValidatorAuthHelpUrl")
+    private PrefixRegistrationRequestValidator authHelpUrlValidator;
+
     @Override
     public List<PrefixRegistrationRequestValidator> getValidationChain() {
         return Arrays.asList(
@@ -112,7 +120,9 @@ public class PrefixRegistrationRequestValidatorStrategyFullValidation implements
                 crossedIdRegexPatternAndSampleIdValidator,
                 referencesValidator,
                 additionalInformationValidator,
-                requesterValidator
+                requesterValidator,
+                authHelpDescriptionValidator,
+                authHelpUrlValidator
         );
     }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorAuthHelpDescription.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorAuthHelpDescription.java
@@ -1,0 +1,35 @@
+package org.identifiers.cloud.hq.ws.registry.models.validators;
+
+import org.identifiers.cloud.hq.ws.registry.api.requests.ServiceRequestRegisterResourcePayload;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Project: registry
+ * Package: org.identifiers.cloud.hq.ws.registry.models.validators
+ * Timestamp: 2019-03-14 15:49
+ *
+ * @author Manuel Bernal Llinares <mbdebian@gmail.com>
+ * ---
+ */
+// TODO I don't think it needs to be of "prototype" scope
+@Component
+@Scope("prototype")
+@Qualifier("ResourceRegistrationRequestValidatorAuthHelpDescription")
+public class ResourceRegistrationRequestValidatorAuthHelpDescription implements ResourceRegistrationRequestValidator {
+    public static final int DESCRIPTION_CONTENT_MIN_CHARS = 50;
+
+    @Override
+    public boolean validate(ServiceRequestRegisterResourcePayload request) throws ResourceRegistrationRequestValidatorException {
+        if (request.isProtectedUrls()) {
+            if (request.getAuthHelpDescription() == null ||
+                    request.getAuthHelpDescription().length() < DESCRIPTION_CONTENT_MIN_CHARS) {
+                throw new ResourceRegistrationRequestValidatorException(
+                        String.format("Authentication description must be longer than %d characters",
+                                DESCRIPTION_CONTENT_MIN_CHARS));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorAuthHelpUrl.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorAuthHelpUrl.java
@@ -1,0 +1,37 @@
+package org.identifiers.cloud.hq.ws.registry.models.validators;
+
+import org.identifiers.cloud.hq.ws.registry.api.requests.ServiceRequestRegisterResourcePayload;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Project: registry
+ * Package: org.identifiers.cloud.hq.ws.registry.models.validators
+ * Timestamp: 2019-03-14 15:49
+ *
+ * @author Manuel Bernal Llinares <mbdebianS@gmail.com>
+ * ---
+ */
+// TODO I don't think it needs to be of "prototype" scope
+@Component
+@Scope("prototype")
+@Qualifier("ResourceRegistrationRequestValidatorAuthHelpUrl")
+public class ResourceRegistrationRequestValidatorAuthHelpUrl implements ResourceRegistrationRequestValidator {
+    @Override
+    public boolean validate(ServiceRequestRegisterResourcePayload request) throws ResourceRegistrationRequestValidatorException {
+        if (request.isProtectedUrls()) {
+            if (request.getAuthHelpUrl() == null || request.getAuthHelpUrl().trim().length() == 0) {
+                throw new ResourceRegistrationRequestValidatorException("MISSING required Provider URL Pattern");
+            }
+            if (!request.getAuthHelpUrl().toLowerCase().startsWith("http")) {
+                throw new ResourceRegistrationRequestValidatorException("INVALID authentication info URL, it must be a HTTP(S) URL");
+            }
+            WebPageChecker webPageChecker = WebPageCheckerFactory.getWebPageChecker();
+            if (!webPageChecker.checkForValidUrl(request.getAuthHelpUrl())) {
+                throw new ResourceRegistrationRequestValidatorException(String.format("Invalid URL '%s'", request.getAuthHelpUrl()));
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorStrategyFullValidation.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/models/validators/ResourceRegistrationRequestValidatorStrategyFullValidation.java
@@ -73,6 +73,14 @@ public class ResourceRegistrationRequestValidatorStrategyFullValidation implemen
     @Qualifier("ResourceRegistrationRequestValidatorRequester")
     private ResourceRegistrationRequestValidator requesterValidator;
 
+    @Autowired
+    @Qualifier("ResourceRegistrationRequestValidatorAuthHelpDescription")
+    private ResourceRegistrationRequestValidator authHelpDescriptionValidator;
+
+    @Autowired
+    @Qualifier("ResourceRegistrationRequestValidatorAuthHelpUrl")
+    private ResourceRegistrationRequestValidator authHelpUrlValidator;
+
     @Override
     public List<ResourceRegistrationRequestValidator> getValidationChain() {
         return Arrays.asList(
@@ -89,7 +97,9 @@ public class ResourceRegistrationRequestValidatorStrategyFullValidation implemen
                 providerUrlPatternValidator,
                 crossedSampleIdProviderUrlPatternValidator,
                 additionalInformationValidator,
-                requesterValidator
+                requesterValidator,
+                authHelpDescriptionValidator,
+                authHelpUrlValidator
         );
     }
 }


### PR DESCRIPTION
Extension to registry to mark resources as protected, i.e. resources that need authentication for access. This is a first step in supporting references to sensitive information. These include a short description on how to gain access and an URL for further information.
Commits:
- Fix to resource not found returning 500
- resources list on namespace
- Protected resources
