### PR TITLE
Optional URL rewrite on namespaces with prefixes embedded in local ids

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,6 +1,5 @@
 # Development environment HQ Registry API Service
 # Author: Manuel Bernal Llinares <mbdebian@gmail.com>
-version: "3.5"
 services:
     postgresql:
         image: postgres

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/ResolutionApiController.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/controllers/ResolutionApiController.java
@@ -1,12 +1,10 @@
 package org.identifiers.cloud.hq.ws.registry.api.controllers;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.hq.ws.registry.api.models.ResolutionApiModel;
 import org.identifiers.cloud.hq.ws.registry.api.responses.ServiceResponseGetResolverDataset;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * Project: registry
@@ -18,13 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("resolutionApi")
+@RequiredArgsConstructor
 public class ResolutionApiController {
-    @Autowired
-    private ResolutionApiModel model;
+    private final ResolutionApiModel model;
 
-    @RequestMapping(value = "/getResolverDataset", method = RequestMethod.GET)
-    public ResponseEntity<?> getResolverDataset() {
-        ServiceResponseGetResolverDataset response = model.getResolverDataset();
+    @GetMapping(value = "/getResolverDataset")
+    public ResponseEntity<?> getResolverDataset(
+            @RequestParam(defaultValue = "false")
+            boolean rewriteForEmbeddedPrefixes
+    ) {
+        ServiceResponseGetResolverDataset response = model.getResolverDataset(rewriteForEmbeddedPrefixes);
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 }

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModel.java
@@ -60,7 +60,7 @@ public class ResolutionApiModel {
         for (Resource resource : namespace.getResources()) {
             String urlPattern = resource.getUrlPattern();
             int templateVarIdx = urlPattern.indexOf("{$id}");
-            int prefixExpectedStart = templateVarIdx - prefix.length() - 1; // -1 to account for color (:) character
+            int prefixExpectedStart = templateVarIdx - prefix.length() - 1; // -1 to account for colon (:) character
             String possiblePrefix = urlPattern.substring(prefixExpectedStart, templateVarIdx);
 
             if (possiblePrefix.equalsIgnoreCase(prefix + ':')) {

--- a/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModel.java
+++ b/src/main/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModel.java
@@ -1,13 +1,16 @@
 package org.identifiers.cloud.hq.ws.registry.api.models;
 
+import lombok.RequiredArgsConstructor;
 import org.identifiers.cloud.hq.ws.registry.api.ApiCentral;
+import org.identifiers.cloud.hq.ws.registry.api.data.models.Namespace;
+import org.identifiers.cloud.hq.ws.registry.api.data.models.Resource;
 import org.identifiers.cloud.hq.ws.registry.api.data.services.NamespaceApiService;
 import org.identifiers.cloud.hq.ws.registry.api.responses.ResolverDatasetPayload;
 import org.identifiers.cloud.hq.ws.registry.api.responses.ServiceResponseGetResolverDataset;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.util.StringUtils.startsWithIgnoreCase;
 
 
 /**
@@ -19,12 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
  * ---
  */
 @Component
+@RequiredArgsConstructor
 public class ResolutionApiModel {
-    @Autowired
-    private NamespaceApiService namespaceApiService;
+    private final NamespaceApiService namespaceApiService;
 
     // Model API
-    public ServiceResponseGetResolverDataset getResolverDataset() {
+    public ServiceResponseGetResolverDataset getResolverDataset(boolean rewriteForEmbeddedPrefixes) {
         // Default response
         ServiceResponseGetResolverDataset response = new ServiceResponseGetResolverDataset();
         response.setApiVersion(ApiCentral.apiVersion);
@@ -32,10 +35,45 @@ public class ResolutionApiModel {
         response.setPayload(new ResolverDatasetPayload());
         try {
             response.getPayload().setNamespaces(namespaceApiService.getNamespaceTreeDownToLeaves());
+            if (rewriteForEmbeddedPrefixes) {
+                response.getPayload()
+                        .getNamespaces()
+                        .stream().filter(Namespace::isNamespaceEmbeddedInLui)
+                        .forEach(ResolutionApiModel::rewriteForEmbeddedPrefixes);
+            }
         } catch (RuntimeException e) {
             response.setHttpStatus(HttpStatus.INTERNAL_SERVER_ERROR);
             response.setErrorMessage(e.getMessage());
         }
         return response;
+    }
+
+    /**
+     * This function changes the input namespace URL pattern and sample ID to account for the prefix being embedded in the LUI.
+     *  This will remove the prefix from the url pattern if it's right before the id template variable.
+     *  It will also add the prefix to the sample ID if it already doesn't have it.
+     * It is assumed that the namespace has the prefix embedded in lui flag set.
+     * @param namespace to be rewritten in place.
+     */
+    static void rewriteForEmbeddedPrefixes(Namespace namespace) {
+        String prefix = namespace.getPrefix();
+        for (Resource resource : namespace.getResources()) {
+            String urlPattern = resource.getUrlPattern();
+            int templateVarIdx = urlPattern.indexOf("{$id}");
+            int prefixExpectedStart = templateVarIdx - prefix.length() - 1; // -1 to account for color (:) character
+            String possiblePrefix = urlPattern.substring(prefixExpectedStart, templateVarIdx);
+
+            if (possiblePrefix.equalsIgnoreCase(prefix + ':')) {
+                String newUrlPattern = //URL pattern without prefix before template variable
+                        urlPattern.substring(0, prefixExpectedStart) +
+                        urlPattern.substring(templateVarIdx);
+                resource.setUrlPattern(newUrlPattern);
+
+                if (!startsWithIgnoreCase(resource.getSampleId(), possiblePrefix)) {
+                    // Also rewrite resource sample ID if necessary and URL was rewritten
+                    resource.setSampleId(possiblePrefix + resource.getSampleId());
+                }
+            }
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.profiles.active=${HQ_WS_REGISTRY_CONFIG_APPLICATION_ACTIVE_PROFILE:authenabled}
+spring.profiles.active=${HQ_WS_REGISTRY_CONFIG_APPLICATION_ACTIVE_PROFILE:}
 spring.application.name=cloud-hq-ws-registry
 server.port=8180
 spring.devtools.add-properties=false

--- a/src/test/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModelTest.java
+++ b/src/test/java/org/identifiers/cloud/hq/ws/registry/api/models/ResolutionApiModelTest.java
@@ -1,0 +1,46 @@
+package org.identifiers.cloud.hq.ws.registry.api.models;
+
+import org.apache.commons.lang3.StringUtils;
+import org.identifiers.cloud.hq.ws.registry.api.data.models.Namespace;
+import org.identifiers.cloud.hq.ws.registry.api.data.models.Resource;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResolutionApiModelTest {
+    @Test
+    void testStripPrefixFromUrlsInplace() {
+        String prefix = "mir";
+
+
+        Namespace namespace = new Namespace();
+        namespace.setPrefix(prefix);
+
+        Resource resource1 = new Resource();
+        resource1.setUrlPattern("https://provider1.com?q=mir:{$id}");
+        Resource resource2 = new Resource();
+        resource2.setUrlPattern("https://provider2.com?q={$id}");
+        Resource resource3 = new Resource();
+        resource3.setUrlPattern("https://provider3.com?q=MIR:{$id}");
+        namespace.setResources(List.of(resource1, resource2, resource3));
+
+
+        ResolutionApiModel.rewriteForEmbeddedPrefixes(namespace);
+
+
+        for (Resource resource : namespace.getResources()) {
+            String pattern = resource.getUrlPattern();
+            var queryParams = UriComponentsBuilder
+                    .fromHttpUrl(pattern).build().getQueryParams();
+            String value = queryParams.getFirst("q");
+
+            String errMessage = String.format("Prefix %s not stripped from pattern %s", prefix, pattern);
+            assertFalse(StringUtils.containsIgnoreCase(value, prefix), errMessage);
+
+            assertEquals("{$id}", value);
+        }
+    }
+}


### PR DESCRIPTION
It has been brought up that the current resolution dataset is difficult to use with systems that embed the prefix in their IDs. The registry already supports this kind of information through our "Prefix embedded in LUI" flag (e.g. [UO namespace](http://identifeirs.org/uo)). Currently, users have to be aware of this flag and rewrite URLs differently depending on whether it is set or not. That is, they have to remove prefixes from IDs when replacing the ID into the URL pattern acquired from the resolution dataset.

This PR adds a flag to the resolution dataset endpoint to rewrite URLs so that users can replace the IDs with prefixes directly into the URL patterns acquired. Only the resources from namespaces with the flag set are rewritten. It also rewrites the sample ID from the affected resources.

This is an optional feature. The current behaviour of the resolution dataset is kept as default to prevent issues with other users of the resolution dataset.